### PR TITLE
Allow optional arguments on route functions

### DIFF
--- a/tinyhttp-codegen/Cargo.toml
+++ b/tinyhttp-codegen/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 syn = { version = "1.0.98", features = ["full"] }
 quote = "1.0.18"
-tinyhttp-internal = { path = "../tinyhttp-internal", version = "0.2.5", default-features = false }
+tinyhttp-internal = { path = "../tinyhttp-internal", version = "0.2.6", default-features = false }

--- a/tinyhttp-internal/src/config.rs
+++ b/tinyhttp-internal/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::BufRead, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::request::Request;
 pub use dyn_clone::DynClone;

--- a/tinyhttp-internal/src/config.rs
+++ b/tinyhttp-internal/src/config.rs
@@ -29,9 +29,12 @@ pub enum Method {
 pub trait Route: DynClone {
     fn get_path(&self) -> &str;
     fn get_method(&self) -> Method;
-    fn get_body(&self) -> fn(Request) -> Vec<u8>;
-    fn post_body(&self) -> fn(Request) -> Vec<u8>;
+    fn get_body(&self) -> Option<fn() -> Vec<u8>>;
+    fn get_body_with(&self) -> Option<fn(Request) -> Vec<u8>>;
+    fn post_body(&self) -> Option<fn() -> Vec<u8>>;
+    fn post_body_with(&self) -> Option<fn(Request) -> Vec<u8>>;
     fn wildcard(&self) -> Option<String>;
+    fn is_args(&self) -> bool;
 }
 
 pub struct HttpListener {
@@ -138,8 +141,24 @@ impl Routes {
 #[derive(Clone)]
 pub struct Config {
     mount_point: Option<String>,
-    get_routes: Option<Vec<(String, fn(Request) -> Vec<u8>, Option<String>)>>,
-    post_routes: Option<Vec<(String, fn(Request) -> Vec<u8>, Option<String>)>>,
+    get_routes: Option<
+        Vec<(
+            String,
+            Option<fn() -> Vec<u8>>,
+            Option<fn(Request) -> Vec<u8>>,
+            Option<String>,
+            bool,
+        )>,
+    >,
+    post_routes: Option<
+        Vec<(
+            String,
+            Option<fn() -> Vec<u8>>,
+            Option<fn(Request) -> Vec<u8>>,
+            Option<String>,
+            bool,
+        )>,
+    >,
     debug: bool,
     pub ssl: bool,
     ssl_chain: Option<String>,
@@ -237,8 +256,20 @@ impl Config {
     /// ```
 
     pub fn routes(mut self, routes: Routes) -> Self {
-        let mut get_routes: Vec<(String, fn(Request) -> Vec<u8>, Option<String>)> = vec![];
-        let mut post_routes: Vec<(String, fn(Request) -> Vec<u8>, Option<String>)> = vec![];
+        let mut get_routes: Vec<(
+            String,
+            Option<fn() -> Vec<u8>>,
+            Option<fn(Request) -> Vec<u8>>,
+            Option<String>,
+            bool,
+        )> = vec![];
+        let mut post_routes: Vec<(
+            String,
+            Option<fn() -> Vec<u8>>,
+            Option<fn(Request) -> Vec<u8>>,
+            Option<String>,
+            bool,
+        )> = vec![];
         let routes = routes.get_stream();
 
         for route in routes {
@@ -250,7 +281,9 @@ impl Config {
                     get_routes.push((
                         clone.get_path().to_string(),
                         clone.get_body(),
+                        clone.get_body_with(),
                         clone.wildcard(),
+                        clone.is_args(),
                     ));
                 }
                 Method::POST => {
@@ -259,7 +292,9 @@ impl Config {
                     post_routes.push((
                         clone.get_path().to_string(),
                         clone.post_body(),
+                        clone.post_body_with(),
                         clone.wildcard(),
+                        clone.is_args(),
                     ));
                 }
             }
@@ -352,7 +387,13 @@ impl Config {
     pub fn get_routes(
         &self,
         path: String,
-    ) -> Option<(String, fn(Request) -> Vec<u8>, Option<String>)> {
+    ) -> Option<(
+        String,
+        Option<fn() -> Vec<u8>>,
+        Option<fn(Request) -> Vec<u8>>,
+        Option<String>,
+        bool,
+    )> {
         match self.get_routes.clone() {
             Some(vec) => {
                 for i in vec {
@@ -365,7 +406,7 @@ impl Config {
                     } else if path.contains(&i.0) && i.2.is_some() {
                         let split = path.split(&i.0).last().unwrap();
 
-                        return Some((i.0.clone(), i.1, Some(split.to_string())));
+                        return Some((i.0.clone(), i.1, i.2, Some(split.to_string()), i.4));
                     } else {
                         return None;
                     }
@@ -376,7 +417,17 @@ impl Config {
         None
     }
 
-    pub fn post_routes(&self) -> Option<Vec<(String, fn(Request) -> Vec<u8>, Option<String>)>> {
+    pub fn post_routes(
+        &self,
+    ) -> Option<
+        Vec<(
+            String,
+            Option<fn() -> Vec<u8>>,
+            Option<fn(Request) -> Vec<u8>>,
+            Option<String>,
+            bool,
+        )>,
+    > {
         self.post_routes.clone()
     }
 

--- a/tinyhttp-internal/src/http.rs
+++ b/tinyhttp-internal/src/http.rs
@@ -155,12 +155,19 @@ fn build_res(req: Request, config: Config) -> Response {
                 #[cfg(feature = "log")]
                 log::info!("Found path in routes!");
 
-                let req_new = req.clone().set_wildcard(vec.2);
+                let req_new = req.clone().set_wildcard(vec.3);
 
-                response = Response::new()
-                    .status_line("HTTP/1.1 200 OK\r\n")
-                    .body(vec.1(req_new))
-                    .mime("text/plain");
+                if !vec.4 {
+                    response = Response::new()
+                        .status_line("HTTP/1.1 200 OK\r\n")
+                        .body(vec.2.unwrap()(req_new))
+                        .mime("text/plain");
+                } else {
+                    response = Response::new()
+                        .status_line("HTTP/1.1 200 OK\r\n")
+                        .body(vec.1.unwrap()())
+                        .mime("text/plain");
+                }
             }
 
             None => match config.get_mount() {
@@ -229,19 +236,36 @@ fn build_res(req: Request, config: Config) -> Response {
                     if c.0 == stat_line[1] {
                         let line = "HTTP/1.1 200 OK\r\n";
                         let req_new = req.clone();
-                        response = response
-                            .clone()
-                            .status_line(line)
-                            .body(c.1(req_new))
-                            .mime("text/plain");
+                        if !c.4 {
+                            response = response
+                                .clone()
+                                .status_line(line)
+                                .body(c.2.unwrap()(req_new))
+                                .mime("text/plain");
+                        } else {
+                            response = response
+                                .clone()
+                                .status_line(line)
+                                .body(c.1.unwrap()())
+                                .mime("text/plain");
+                        }
                     } else if stat_line[1].contains(&c.0) && c.2.is_some() {
                         let line = "HTTP/1.1 200 OK\r\n";
                         let split = stat_line[1].split(&c.0).last().unwrap();
                         let req_new = req.clone().set_wildcard(Some(split.to_string()));
-                        response = response
-                            .status_line(line)
-                            .body(c.1(req_new))
-                            .mime("text/plain");
+                        if !c.4 {
+                            response = response
+                                .clone()
+                                .status_line(line)
+                                .body(c.1.unwrap()())
+                                .mime("text/plain");
+                        } else {
+                            response = response
+                                .clone()
+                                .status_line(line)
+                                .body(c.2.unwrap()(req_new))
+                                .mime("text/plain");
+                        }
                     }
                 }
             }

--- a/tinyhttp/src/bin/example.rs
+++ b/tinyhttp/src/bin/example.rs
@@ -3,13 +3,13 @@ use std::net::TcpListener;
 use tinyhttp::prelude::*;
 
 #[get("/")]
-fn get(_req: Request) -> &'static str {
+fn get() -> &'static str {
     "Hello, there!\n"
 }
 
 #[post("/")]
 fn post(body: Request) -> String {
-    format!("Hello, {:?}\n", body.get_raw_body())
+    format!("Hello, {:?}\n", body.get_parsed_body().unwrap())
 }
 
 fn main() {


### PR DESCRIPTION
Allow route functions to be written without a Request argument

Example:
```rust
#[get("/")]
fn get() -> &'static str {
  "No arguments! :)"
}
```
